### PR TITLE
Fix segfault when calling yaconv more than once

### DIFF
--- a/addon/yaconv/yaconv.c
+++ b/addon/yaconv/yaconv.c
@@ -207,6 +207,10 @@ static void yaconv_init_once(int W, int FW, int C) {
 static void yaconv_deinit() {
   // All buffers are actually at different offsets within one
   free(filter_buf);
+  free(auxinfo);
+  // Ensure yaconv_init_once will allocate buffer on
+  // subsequent calls to yaconv.
+  filter_buf = NULL;
 }
 
 // This function performs intitialization of BLIS structures, block sizes and


### PR DESCRIPTION
yaconv_init_once relies on checking if filter_buf is null to detect if it is allocated. The problem is that calling free on filter_buf does not set said pointer to null. This commit fixes this by setting said pointer to null upon deinit.

This commit also frees auxinfo to avoid a memory leak.

Bug was identified by @caio96